### PR TITLE
feat/#41 작물 병해에 따른 페이지 이동

### DIFF
--- a/src/pages/AbnomalResultPage.tsx
+++ b/src/pages/AbnomalResultPage.tsx
@@ -5,8 +5,11 @@ import tomato3 from "src/images/tomato3.jpg";
 import die from "src/images/dietomato.png";
 import "src/media.css";
 import Navbar from "src/components/Navbar";
+import { useLocation } from "react-router-dom";
 
 const ResultPage = () => {
+  const { state } = useLocation();
+  console.log(state)
   return (
     // 전체
     <div className="relative flex max-h-screen w-screen flex-col overflow-y-auto bg-background bg-grass bg-no-repeat">

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -78,8 +78,11 @@ const MainPage = () => {
         } 
           )
         .then((res) => {
-          navigate("/abnomalresult", { state: res.status });
-          console.log(res.data)
+          if(res.data.disease_name === "정상"){
+            navigate("/nomalresult", { state: res.data });
+          }else{
+            navigate("/abnomalresult", { state: res.data });
+          }
           
         })
         .catch((error) => {
@@ -164,8 +167,6 @@ const plantIndexHandler = (e:any) => {
               <button
                 className="h-10 w-full rounded-lg bg-button text-white"
                  onClick={getResult}
-                 
-      
               >
                 <b>진단하기</b>
               </button>


### PR DESCRIPTION
## 추가한 기능 설명

### 작물 병해 진단 결과 - 비정상
<img width="831" alt="스크린샷 2023-01-19 오후 2 27 46" src="https://user-images.githubusercontent.com/83527046/213362633-97b63a86-c8e3-47d9-bdbd-61d5a028bffc.png">

<img width="904" alt="스크린샷 2023-01-19 오후 2 26 10" src="https://user-images.githubusercontent.com/83527046/213362529-9831a6ad-2332-4354-8f1d-51cf6417c952.png">

### 작물 병해 진단 결과 - 정상

<img width="836" alt="스크린샷 2023-01-19 오후 2 28 03" src="https://user-images.githubusercontent.com/83527046/213362674-bcf918a6-dfa5-4282-9c41-3aef34cc1387.png">

<img width="815" alt="스크린샷 2023-01-19 오후 2 27 25" src="https://user-images.githubusercontent.com/83527046/213362593-3bb1c7de-ccbb-49c8-aec3-9121b920c1b5.png">

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?

