### PR TITLE
Feat/#52 결과에 따른 페이지 이동 및 결과 데이터 반환

### DIFF
--- a/src/pages/AbnomalResultPage.tsx
+++ b/src/pages/AbnomalResultPage.tsx
@@ -8,8 +8,9 @@ import Navbar from "src/components/Navbar";
 import { useLocation } from "react-router-dom";
 
 const ResultPage = () => {
-  const { state } = useLocation();
-  console.log(state)
+  const location = useLocation();
+  console.log(location)
+
   return (
     // 전체
     <div className="relative flex max-h-screen w-screen flex-col overflow-y-auto bg-background bg-grass bg-no-repeat">
@@ -22,11 +23,11 @@ const ResultPage = () => {
         <div className="content-center pt-24">
           <div className="flex flex-col ">
             <img
-              src={tomato2}
+              src={location.state.result_url}
               className="sub_tomato1 h-356 w-600 rounded-xl object-cover"
             />
             <div className="mt-2  flex flex-col items-center font-kor-bold text-xl  ">
-              잿빛 곰팡이병
+              {location.state.disease_name}
             </div>
           </div>
           <div className="mt-5 h-356 w-600 object-cover">
@@ -51,14 +52,14 @@ const ResultPage = () => {
             <div className="font-kor-bold text-2xl">
               진단결과&nbsp;&nbsp;
               <span className="font-kor-bold text-disease">
-                토마토 잿빛곰팡이병
+              {location.state.disease_name}
               </span>
               으로 의심됩니다.
             </div>
             <div className="flex">
               <img src={die} className="die_tomato"></img>
               <div className="flex place-items-end font-kor-medium">
-                우리의 토마토는 가셨습니다..
+                우리의 {location.state.plant_name}는 가셨습니다..
               </div>
             </div>
           </div>
@@ -66,76 +67,19 @@ const ResultPage = () => {
             <div className="place-content-between">
               <div className="mb-2 font-eng-bold text-2xl">Causation</div>
               <div className="font-kor-regula mb-7 h-130 max-w-2xl overflow-y-auto border-black text-xl">
-                이 병은 습도가 높으면 발병이 많으므로 시설 내부가 다습하지
-                않도록 가능한 관수량을 줄이고 환기를 충분히 실시하여 재배하고,
-                저온기 재배시에는 온도조절만이 아니라 난방을 하여 습기를
-                제거한다. 불규칙적인 기상조건에서는 난방과 함께 약제살포를
-                병행처리하여 방제한다. 약제방제로는 유파렌수화제 600배액,
-                포리옥신수화제 1,000배액, 더마니수용제 5,000배액, 톱신수화제
-                1,000배액, 프로파수화제 1,000배액을 7∼8일간이 병은 습도가 높으면
-                발병이 많으므로 시설 내부가 다습하지 않도록 가능한 관수량을
-                줄이고 환기를 충분히 실시하여 재배하고, 저온기 재배시에는
-                온도조절만이 아니라 난방을 하여 습기를 제거한다. 불규칙적인
-                기상조건에서는 난방과 함께 약제살포를 병행처리하여 방제한다.
-                약제방제로는 유파렌수화제 600배액, 포리옥신수화제 1,000배액,
-                더마니수용제 5,000배액, 톱신수화제 1,000배액, 프로파수화제
-                1,000배액을 7∼8일간이 병은 습도가 높으면 발병이 많으므로 시설
-                내부가 다습하지 않도록 가능한 관수량을 줄이고 환기를 충분히
-                실시하여 재배하고, 저온기 재배시에는 온도조절만이 아니라 난방을
-                하여 습기를 제거한다. 불규칙적인 기상조건에서는 난방과 함께
-                약제살포를 병행처리하여 방제한다. 약제방제로는 유파렌수화제
-                600배액, 포리옥신수화제 1,000배액, 더마니수용제 5,000배액,
-                톱신수화제 1,000배액, 프로파수화제 1,000배액을 7∼8일간
+                {location.state.feature}
               </div>
             </div>
             <div>
               <div className="mb-2 font-eng-bold text-2xl">Symptom</div>
               <div className="mb-7 h-130 max-w-2xl overflow-y-auto border-black font-kor-regular text-xl">
-                이 병은 습도가 높으면 발병이 많으므로 시설 내부가 다습하지
-                않도록 가능한 관수량을 줄이고 환기를 충분히 실시하여 재배하고,
-                저온기 재배시에는 온도조절만이 아니라 난방을 하여 습기를
-                제거한다. 불규칙적인 기상조건에서는 난방과 함께 약제살포를
-                병행처리하여 방제한다. 약제방제로는 유파렌수화제 600배액,
-                포리옥신수화제 1,000배액, 더마니수용제 5,000배액, 톱신수화제
-                1,000배액, 프로파수화제 1,000배액을 7∼8일간이 병은 습도가 높으면
-                발병이 많으므로 시설 내부가 다습하지 않도록 가능한 관수량을
-                줄이고 환기를 충분히 실시하여 재배하고, 저온기 재배시에는
-                온도조절만이 아니라 난방을 하여 습기를 제거한다. 불규칙적인
-                기상조건에서는 난방과 함께 약제살포를 병행처리하여 방제한다.
-                약제방제로는 유파렌수화제 600배액, 포리옥신수화제 1,000배액,
-                더마니수용제 5,000배액, 톱신수화제 1,000배액, 프로파수화제
-                1,000배액을 7∼8일간이 병은 습도가 높으면 발병이 많으므로 시설
-                내부가 다습하지 않도록 가능한 관수량을 줄이고 환기를 충분히
-                실시하여 재배하고, 저온기 재배시에는 온도조절만이 아니라 난방을
-                하여 습기를 제거한다. 불규칙적인 기상조건에서는 난방과 함께
-                약제살포를 병행처리하여 방제한다. 약제방제로는 유파렌수화제
-                600배액, 포리옥신수화제 1,000배액, 더마니수용제 5,000배액,
-                톱신수화제 1,000배액, 프로파수화제 1,000배액을 7∼8일간
+              {location.state.plant_explaination}
               </div>
             </div>
             <div>
               <div className="mb-2  font-eng-bold text-2xl">Cure</div>
               <div className="mb-7 h-130 max-w-2xl overflow-y-auto border-black font-kor-regular text-xl">
-                이 병은 습도가 높으면 발병이 많으므로 시설 내부가 다습하지
-                않도록 가능한 관수량을 줄이고 환기를 충분히 실시하여 재배하고,
-                저온기 재배시에는 온도조절만이 아니라 난방을 하여 습기를
-                제거한다. 불규칙적인 기상조건에서는 난방과 함께 약제살포를
-                병행처리하여 방제한다. 약제방제로는 유파렌수화제 600배액,
-                포리옥신수화제 1,000배액, 더마니수용제 5,000배액, 톱신수화제
-                1,000배액, 프로파수화제 1,000배액을 7∼8일간이 병은 습도가 높으면
-                발병이 많으므로 시설 내부가 다습하지 않도록 가능한 관수량을
-                줄이고 환기를 충분히 실시하여 재배하고, 저온기 재배시에는
-                온도조절만이 아니라 난방을 하여 습기를 제거한다. 불규칙적인
-                기상조건에서는 난방과 함께 약제살포를 병행처리하여 방제한다.
-                약제방제로는 유파렌수화제 600배액, 포리옥신수화제 1,000배액,
-                더마니수용제 5,000배액, 톱신수화제 1,000배액, 프로파수화제
-                1,000배액을 7∼8일간이 병은 습도가 높으면 발병이 많으므로 시설
-                내부가 다습하지 않도록 가능한 관수량을 줄이고 환기를 충분히
-                실시하여 재배하고, 저온기 재배시에는 온도조절만이 아니라 난방을
-                하여 습기를 제거한다. 불규칙적인 기상조건에서는 난방과 함께
-                약제살포를 병행처리하여 방제한다. 약제방제로는 유파렌수화제
-                600배액, 포리옥신수화제 1,000배액, 더마니수용제 5,000배액,
-                톱신수화제 1,000배액, 프로파수화제 1,000배액을 7∼8일간
+              {location.state.solution}
               </div>
             </div>
           </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -73,10 +73,11 @@ const MainPage = () => {
         params: { picture: imageName, type: plantIndex },
       })
       .then((res) => {
+        console.log(res.data)
         if (res.data.disease_name === "정상") {
           navigate("/nomalresult", { state: res.data });
         } else {
-          navigate("/nomalresult", { state: res.data });
+          navigate("/abnomalresult", { state: res.data });
         }
       })
       .catch((error) => {


### PR DESCRIPTION
## 추가한 기능 설명

###  결과에 따른 페이지 이동 및 결과 데이터 페이지에 반환
<img width="1036" alt="스크린샷 2023-01-20 오후 6 58 44" src="https://user-images.githubusercontent.com/83527046/213667780-0250ffde-8349-49a4-9199-1c09785c5014.png">

<img width="861" alt="스크린샷 2023-01-20 오후 6 59 59" src="https://user-images.githubusercontent.com/83527046/213668034-539e28a3-59f5-4932-8a4a-a379d3e71875.png">
<br>

## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?

