### PR TITLE
fix/#104: 로그인 & 회원가입 배경 이미지 변경

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -32,7 +32,7 @@ module.exports = {
       },
       backgroundImage: {
         grass: "url('src/images/grass.svg')",
-        startImg: "url('images/backImg.svg')",
+        startImg: "url('images/backImg.png')",
         diagnosis: "url('images/diagnosis.svg')",
         diagnosis_hover: "url('images/diagnosis_hover.svg')",
         login: "url('images/login.svg')",


### PR DESCRIPTION
## 추가한 기능 설명
svg용량이 10MB가 이상이므로 로딩하는데 시간이 오래 걸려서 png로 확장자 변경하여 용량을 반 이상 낮췄음

- 27인치 모니터로 확인한 바 사진 배경이 깨지진 않았음! 
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?

