### PR TITLE
fix/#104 히스토리 페이지 렌더링 작업 및 메인 페이지 버튼 활성화

### DIFF
--- a/src/components/Historycard.tsx
+++ b/src/components/Historycard.tsx
@@ -24,15 +24,19 @@ function Historycard(props: any) {
             onClick={() =>
               axios
                 .delete(
-                  `https://api.cropdoctor.shop/api/v1/plants/histories/${props.items.id}/`,{
-                    headers : {
-                      Authorization : `Bearer ${userCookie}`
+                  `https://api.cropdoctor.shop/api/v1/plants/histories/${props.items.id}/`,
+                  {
+                    headers: {
+                      Authorization: `Bearer ${userCookie}`,
                     },
                   }
                 ) //api 주소
                 .then((res) => {
-                  console.log(res);
-                  props.restate(); //히스토리 페이지 새로고침
+                  props.setHistory(
+                    props.history.filter(
+                      (item: { id: number }) => item.id !== props.items.id
+                    )
+                  );
                 })
                 .catch((error) => {
                   console.log(error);

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -18,10 +18,7 @@ const HistoryPage = () => {
   const indexHandler = (e: any) => {
     setIndex((index) => e.target.value);
   }; //카테고리 밸류값 인덱스에 저장
-  const restate = () => {
-    location.reload();
-  }; //히스토리 삭제시 새로고침
-  // 카테고리 선택한거에 따라 map하고 자식컴포넌트에 값 전달
+
   function Mapping() {
     if (index < 7 && index >= 1) {
       //1번 고추부터 6번 토마토까지
@@ -30,7 +27,12 @@ const HistoryPage = () => {
           {/*작물 id가 카테고리 인덱스와 같은지 검사 후 같은것만 map*/}
           {reversed.map((item: any[], num: number) =>
             reversed[num].plant.id == index ? (
-              <Historycard items={item} key={num} restate={restate} />
+              <Historycard
+                items={item}
+                key={num}
+                setHistory={setHistory}
+                history={history}
+              />
             ) : null
           )}
         </div>
@@ -40,22 +42,26 @@ const HistoryPage = () => {
       return (
         <div className="flex flex-wrap">
           {reversed.map((item: any, num: number) => (
-            <Historycard items={item} key={num} restate={restate} />
+            <Historycard
+              items={item}
+              key={num}
+              setHistory={setHistory}
+              history={history}
+            />
           ))}
         </div>
       );
     }
   }
-  //데이터 가져올 함수 정의
   useEffect(() => {
     (async () => {
       setLoading(true);
       await axios
         .get("https://api.cropdoctor.shop/api/v1/plants/histories/", {
-        headers : {
-          Authorization : `Bearer ${userCookie}`
-        },
-      })
+          headers: {
+            Authorization: `Bearer ${userCookie}`,
+          },
+        })
         .then((res) => {
           setHistory([...res.data.result]); //history에 요청한 데이터 저장
           console.log(history);
@@ -64,7 +70,7 @@ const HistoryPage = () => {
         .catch((error) => {
           console.log(error);
           alert("히스토리 불러오기 실패. 로그인이 되어있는지 확인하세요.");
-          navigate('/');
+          navigate("/");
         });
     })();
   }, []);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -29,9 +29,6 @@ const MainPage = () => {
       alert("카테고리를 선택해 주세요");
       return;
     }
-    if (file != null) {
-      setButtonOn(true);
-    }
     setImage(file);
     setPreviewUrl(URL.createObjectURL(file));
     const formData = new FormData();
@@ -46,6 +43,7 @@ const MainPage = () => {
     })
       .then(function (response: any) {
         console.log(response.data);
+        setButtonOn(true);
         setImageName(response.data.url);
       })
       .catch(function (error) {
@@ -78,8 +76,8 @@ const MainPage = () => {
     await axios
       .get("https://api.cropdoctor.shop/api/v1/plants/ais/", {
         params: { picture: imageName, type: plantIndex },
-        headers : {
-          Authorization : `Bearer ${userCookie}`
+        headers: {
+          Authorization: `Bearer ${userCookie}`,
         },
       })
       .then((res) => {
@@ -96,10 +94,6 @@ const MainPage = () => {
         console.log(error);
       });
   };
-
-  // useEffect(() => {
-  //   getResult();
-  // }, []);
 
   const plantIndexHandler = (e: any) => {
     setPlantIndex(e.target.value); // 작물 인덱스


### PR DESCRIPTION
## 추가한 기능 설명
- 히스토리 페이지 삭제 시 새로고침이 아닌 렌더링이 되게 수정
- 메인 페이지에서 분석 사진 업로드 후 진단하기 버튼 활성화
<br>

## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?

